### PR TITLE
UNET & Text Encoder run in different stage to save VRAM

### DIFF
--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -70,6 +70,7 @@ class DreamboothConfig:
                  use_ema: bool = True,
                  use_lora: bool = False,
                  use_unet: bool = True,
+                 use_stages: bool = False,
                  v2: bool = False,
                  c1_class_data_dir: str = "",
                  c1_class_guidance_scale: float = 7.5,
@@ -187,6 +188,7 @@ class DreamboothConfig:
         self.use_ema = False if use_ema is None else use_ema
         self.use_lora = False if use_lora is None else use_lora
         self.use_unet = False if use_unet is None else use_unet
+        self.use_stages = False if use_stages is None else use_stages
         if scheduler is not None:
             self.scheduler = scheduler
 

--- a/dreambooth/dreambooth.py
+++ b/dreambooth/dreambooth.py
@@ -350,27 +350,42 @@ def start_training(model_dir: str, lora_model_name: str, lora_alpha: float, lora
     unload_system_models()
     total_steps = config.revision
 
-    try:
-        if imagic_only:
-            shared.state.textinfo = "Initializing imagic training..."
-            print(shared.state.textinfo)
-            from extensions.sd_dreambooth_extension.dreambooth.train_imagic import train_imagic
-            mem_record = train_imagic(config, mem_record)
-        else:
-            shared.state.textinfo = "Initializing dreambooth training..."
-            print(shared.state.textinfo)
-            from extensions.sd_dreambooth_extension.dreambooth.train_dreambooth import main
-            config, mem_record, msg = main(config, mem_record, use_subdir=use_subdir, lora_model=lora_model_name,
-                                           lora_alpha=lora_alpha, lora_txt_alpha=lora_txt_alpha, custom_model_name=custom_model_name)
-            if config.revision != total_steps:
-                config.save()
-        total_steps = config.revision
-        res = f"Training {'interrupted' if shared.state.interrupted else 'finished'}. " \
-              f"Total lifetime steps: {total_steps} \n"
-    except Exception as e:
-        res = f"Exception training model: {e}"
-        traceback.print_exc()
-        pass
+    stage_enable = config.use_stages and config.use_unet and config.train_text_encoder
+    stage_steps = [1, 2] if stage_enable else [1]
+    for stage in stage_steps:
+        if stage_enable:
+            print("=========================================================")
+            print("UNET and Text Encoder will train separately to save VRAM!")
+            print("=========================================================")
+        if stage_enable and stage == 1:
+            config.use_unet = False
+            config.train_text_encoder = True
+            print ("Stage 1: Text Encoder\n")
+        if stage_enable and stage == 2:
+            config.use_unet = True
+            config.train_text_encoder = False
+            print ("Stage 2: UNET\n")
+        try:
+            if imagic_only:
+                shared.state.textinfo = "Initializing imagic training..."
+                print(shared.state.textinfo)
+                from extensions.sd_dreambooth_extension.dreambooth.train_imagic import train_imagic
+                mem_record = train_imagic(config, mem_record)
+            else:
+                shared.state.textinfo = "Initializing dreambooth training..."
+                print(shared.state.textinfo)
+                from extensions.sd_dreambooth_extension.dreambooth.train_dreambooth import main
+                config, mem_record, msg = main(config, mem_record, use_subdir=use_subdir, lora_model=lora_model_name,
+                                            lora_alpha=lora_alpha, lora_txt_alpha=lora_txt_alpha, custom_model_name=custom_model_name)
+                if config.revision != total_steps:
+                    config.save()
+            total_steps = config.revision
+            res = f"Training {'interrupted' if shared.state.interrupted else 'finished'}. " \
+                f"Total lifetime steps: {total_steps} \n"
+        except Exception as e:
+            res = f"Exception training model: {e}"
+            traceback.print_exc()
+            pass
 
     devices.torch_gc()
     gc.collect()

--- a/dreambooth/dreambooth.py
+++ b/dreambooth/dreambooth.py
@@ -261,6 +261,7 @@ def load_params(model_dir):
                "db_use_ema",
                "db_use_lora",
                "db_use_unet",
+               "db_use_stages",
                "c1_class_data_dir", "c1_class_guidance_scale", "c1_class_infer_steps",
                "c1_class_negative_prompt", "c1_class_prompt", "c1_class_token",
                "c1_instance_data_dir", "c1_instance_prompt", "c1_instance_token", "c1_max_steps", "c1_n_save_sample",

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -127,7 +127,9 @@ new_titles = {
     "Use Concepts List": "Train multiple concepts from a JSON file or string.",
     "Use Lifetime Steps/Epochs When Saving": "When checked, will save preview images and checkpoints using lifetime steps/epochs, versus current training steps.",
     "Use EMA": "Enabling this will provide better results and editability, but cost more VRAM.",
-    "Use LORA": "Uses Low-rank Adaptation for Fast Text-to-Image Diffusion Fine-tuning. Uses less VRAM, saves a .pt file instead of a full checkpoint"
+    "Use LORA": "Uses Low-rank Adaptation for Fast Text-to-Image Diffusion Fine-tuning. Uses less VRAM, saves a .pt file instead of a full checkpoint",
+    "Use UNET": "UNET is a deep learning model used for image segmentation. It consists of a contracting path to capture context and a symmetric expanding path that enables precise localization. It is trained end-to-end to classify each pixel in an image.",
+    "Train UNET and Text Encoder Separately": "Train UNET and Text Encoder in different stages for > 10GB GPUs to provide better results and editability.",
 }
 
 ex_titles = Object.assign({}, ex_titles, new_titles);

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -153,6 +153,7 @@ def on_ui_tabs():
                                     db_use_ema = gr.Checkbox(label="Use EMA", value=False)
                                     db_use_unet = gr.Checkbox(label="Use UNET", value=True)
                                     db_use_8bit_adam = gr.Checkbox(label="Use 8bit Adam", value=False)
+                                    db_use_stages = gr.Checkbox(label="Train UNET and Text Encoder Separately", value=False)
                                     db_mixed_precision = gr.Dropdown(label="Mixed Precision", value="no",
                                                                      choices=list_floats())
                                     db_attention = gr.Dropdown(
@@ -290,6 +291,7 @@ def on_ui_tabs():
                 db_use_ema,
                 db_use_lora,
                 db_use_unet,
+                db_use_stages,
                 db_v2,
                 c1_class_data_dir,
                 c1_class_guidance_scale,
@@ -399,6 +401,7 @@ def on_ui_tabs():
                 db_use_ema,
                 db_use_lora,
                 db_use_unet,
+                db_use_stages,
                 c1_class_data_dir,
                 c1_class_guidance_scale,
                 c1_class_infer_steps,


### PR DESCRIPTION
I can confirmed his code works on my 3080 10GB GPU
Since it require user intervention to run 2nd stage, I made little changes that train both stages.
Now it can train **UNET** and **Text Encoder** separately and automatically!
![image](https://user-images.githubusercontent.com/1908715/208171449-7b741754-9e01-469a-ad28-ee59cb2779e3.png)

Console Output:
![Stage 1](https://user-images.githubusercontent.com/1908715/208174921-862835c0-42c3-4f1f-beea-c3be216e343d.png)
![Stage 2](https://user-images.githubusercontent.com/1908715/208176293-def8d29b-ae4c-4b56-b3ac-1db885e64a48.png)

To RTX 3080 10GB users, you can use this changes by using `gh pr checkout 558` (require [GitHub CLI](https://cli.github.com/))

:3