### PR TITLE
d8ahazard recommendation

### DIFF
--- a/dreambooth/db_config.py
+++ b/dreambooth/db_config.py
@@ -69,8 +69,8 @@ class DreamboothConfig:
                  use_cpu: bool = False,
                  use_ema: bool = True,
                  use_lora: bool = False,
-                 use_unet: bool = True,
-                 use_stages: bool = False,
+                 train_unet: bool = True,
+                 train_in_stages: bool = False,
                  stage_step_ratio: float = 1.0,
                  v2: bool = False,
                  c1_class_data_dir: str = "",
@@ -188,8 +188,8 @@ class DreamboothConfig:
         self.use_cpu = use_cpu
         self.use_ema = False if use_ema is None else use_ema
         self.use_lora = False if use_lora is None else use_lora
-        self.use_unet = False if use_unet is None else use_unet
-        self.use_stages = False if use_stages is None else use_stages
+        self.train_unet = False if train_unet is None else train_unet
+        self.train_in_stages = False if train_in_stages is None else train_in_stages
         self.stage_step_ratio = stage_step_ratio
         if scheduler is not None:
             self.scheduler = scheduler

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -558,11 +558,11 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
     if not args.train_text_encoder:
         text_encoder.requires_grad_(False)
 
-    if not args.use_unet:
+    if not args.train_unet:
         unet.requires_grad_(False)        
 
     if args.gradient_checkpointing:
-        if args.use_unet:
+        if args.train_unet:
             unet.enable_gradient_checkpointing()
         if args.train_text_encoder:
             text_encoder.gradient_checkpointing_enable()
@@ -621,7 +621,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
         )
     else:
         params_to_optimize = (
-            itertools.chain(text_encoder.parameters()) if args.train_text_encoder and not args.use_unet else 
+            itertools.chain(text_encoder.parameters()) if args.train_text_encoder and not args.train_unet else 
             itertools.chain(unet.parameters(), text_encoder.parameters()) if args.train_text_encoder else 
             unet.parameters()
         )
@@ -834,7 +834,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
     total_batch_size = args.train_batch_size * accelerator.num_processes * args.gradient_accumulation_steps
     stats = f"CPU: {args.use_cpu}, Adam: {use_adam}, Prec: {args.mixed_precision}, " \
             f"Grad: {args.gradient_checkpointing}, TextTr: {args.train_text_encoder}, EM: {args.use_ema}, " \
-            f"LR: {args.learning_rate}, LORA: {args.use_lora}, UNET: {args.use_unet}"
+            f"LR: {args.learning_rate}, LORA: {args.use_lora}, UNET: {args.train_unet}"
 
     print("***** Running training *****")
     print(f"  Num examples = {len(train_dataset)}")
@@ -987,7 +987,7 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
         if training_complete:
             break
         try:
-            if args.use_unet:
+            if args.train_unet:
                 unet.train()
             if args.train_text_encoder and text_encoder is not None:
                 text_encoder.train()

--- a/javascript/dreambooth.js
+++ b/javascript/dreambooth.js
@@ -128,7 +128,7 @@ new_titles = {
     "Use Lifetime Steps/Epochs When Saving": "When checked, will save preview images and checkpoints using lifetime steps/epochs, versus current training steps.",
     "Use EMA": "Enabling this will provide better results and editability, but cost more VRAM.",
     "Use LORA": "Uses Low-rank Adaptation for Fast Text-to-Image Diffusion Fine-tuning. Uses less VRAM, saves a .pt file instead of a full checkpoint",
-    "Use UNET": "UNET is a deep learning model used for image segmentation. It consists of a contracting path to capture context and a symmetric expanding path that enables precise localization. It is trained end-to-end to classify each pixel in an image.",
+    "Train UNET": "UNET is a deep learning model used for image segmentation. It consists of a contracting path to capture context and a symmetric expanding path that enables precise localization. It is trained end-to-end to classify each pixel in an image.",
     "Train Text Encoder and UNET in Two Stages": "Train UNET and Text Encoder in different stages for > 10GB GPUs to provide better results and editability.",
     "Step Ratio of Text Encoder Training": "When using Two Stage Training, scale the Text Encoder to reduce training time, increasing might give better results at cost of time."
 }

--- a/scripts/main.py
+++ b/scripts/main.py
@@ -151,7 +151,6 @@ def on_ui_tabs():
                                     db_use_cpu = gr.Checkbox(label="Use CPU Only (SLOW)", value=False)
                                     db_use_lora = gr.Checkbox(label="Use LORA", value=False)
                                     db_use_ema = gr.Checkbox(label="Use EMA", value=False)
-                                    db_use_unet = gr.Checkbox(label="Use UNET", value=True)
                                     db_use_8bit_adam = gr.Checkbox(label="Use 8bit Adam", value=False)
                                     db_mixed_precision = gr.Dropdown(label="Mixed Precision", value="no",
                                                                      choices=list_floats())
@@ -160,8 +159,9 @@ def on_ui_tabs():
                                         choices=list_attention())
 
                                     db_not_cache_latents = gr.Checkbox(label="Don't Cache Latents", value=True)
+                                    db_train_unet = gr.Checkbox(label="Train UNET", value=True)
                                     db_train_text_encoder = gr.Checkbox(label="Train Text Encoder", value=True)
-                                    db_use_stages = gr.Checkbox(label="Train Text Encoder and UNET in Two Stages", value=False)
+                                    db_train_in_stages = gr.Checkbox(label="Train Text Encoder and UNET in Two Stages", value=False)
                                     db_stage_step_ratio = gr.Slider(label="Step Ratio of Text Encoder Training", minimum=0, maximum=2, step=0.01, value=1, visible=False)
                                     db_prior_loss_weight = gr.Number(label="Prior Loss Weight", value=1.0, precision=1)
                                     db_pad_tokens = gr.Checkbox(label="Pad Tokens", value=True)
@@ -291,8 +291,8 @@ def on_ui_tabs():
                 db_use_cpu,
                 db_use_ema,
                 db_use_lora,
-                db_use_unet,
-                db_use_stages,
+                db_train_unet,
+                db_train_in_stages,
                 db_stage_step_ratio,
                 db_v2,
                 c1_class_data_dir,
@@ -402,8 +402,8 @@ def on_ui_tabs():
                 db_use_cpu,
                 db_use_ema,
                 db_use_lora,
-                db_use_unet,
-                db_use_stages,
+                db_train_unet,
+                db_train_in_stages,
                 db_stage_step_ratio,
                 c1_class_data_dir,
                 c1_class_guidance_scale,
@@ -487,11 +487,11 @@ def on_ui_tabs():
             outputs=[db_use_lora],
         )
 
-        db_use_stages.change(
+        db_train_in_stages.change(
             fn=lambda x: {
                 db_stage_step_ratio: gr_show(x is True)
             },
-            inputs=[db_use_stages],
+            inputs=[db_train_in_stages],
             outputs=[db_stage_step_ratio]
         )
 
@@ -552,8 +552,8 @@ def on_ui_tabs():
                 db_use_8bit_adam,
                 db_use_cpu,
                 db_use_ema,
-                db_use_unet,
-                db_use_stages,
+                db_train_unet,
+                db_train_in_stages,
                 db_use_lora
             ]
         )


### PR DESCRIPTION
> For the UI stuff, I think it'd make more sense to change it from "Use UNET" to "Train UNET", and put the "Train Text Encoder" setting between it and "Train in 2 stages" or whatever it's called.

![image](https://user-images.githubusercontent.com/1908715/208284066-2b734512-1f52-48a5-8cb7-cdfcc9206f62.png)

> Also, in the start_training method, you should add a check to the others to ensure that at least the unet or text encoder are enabled for training (or lora, idk if this affects that), but basically, a sanity check to ensure that something is going to be trained.

Console Output:
UNET and or Text Encoder is disabled while Train in Stages enabled:
```
Concept 0 class dir is E:\dreambooth\_REGULARIZATION-IMAGES\1girl
Multi-Stage training require both Train UNET and Train Text Encoder to be enable.
```
When Train in Stages and LoRA both enabled:
```
Concept 0 class dir is E:\dreambooth\_REGULARIZATION-IMAGES\1girl
Multi-Stage training cannot continue if LoRA enabled, disable either one.
```