### PR TITLE
Text Encoder training crash when Generate Class Image complete

### DIFF
--- a/dreambooth/dreambooth.py
+++ b/dreambooth/dreambooth.py
@@ -409,6 +409,7 @@ def start_training(model_dir: str, lora_model_name: str, lora_alpha: float, lora
                     config.train_text_encoder = False
                     config.gradient_accumulation_steps = grad_steps
                     config.num_train_epochs = epochs
+                    [setattr(concept, 'num_class_images', 0) for concept in config.concepts_list]
                     print ("Stage 2: UNET\n")
 
                 config, mem_record, msg = main(config, mem_record, use_subdir=use_subdir, lora_model=lora_model_name,

--- a/dreambooth/dreambooth.py
+++ b/dreambooth/dreambooth.py
@@ -345,12 +345,13 @@ def start_training(model_dir: str, lora_model_name: str, lora_alpha: float, lora
         msg = "Invalid Pretrained VAE Path."
     if config.resolution <= 0:
         msg = "Invalid resolution."
-    if config.train_in_stages and (not config.train_unet or not config.train_text_encoder):
-        msg = "Multi-Stage training require both Train UNET and Train Text Encoder to be enable."
-    if config.train_in_stages and config.use_lora:
-        msg = "Multi-Stage training cannot continue if LoRA enabled, disable either one." # Why use Multi-Stage when LoRA can be train on <= 8GB GPUs
-    if config.train_in_stages and config.use_ema:
-        msg = "Multi-Stage training cannot continue if EMA enabled, disable Use EMA." # <= 10GB GPU cannot train with EMA enable
+    if config.train_in_stages:
+        if not config.train_unet or not config.train_text_encoder:
+            msg = "Multi-Stage training require both Train UNET and Train Text Encoder to be enable."
+        if config.use_lora:
+            msg = "Multi-Stage training cannot continue if LoRA enabled, disable either one." # Why use Multi-Stage when LoRA can be train on <= 8GB GPUs
+        if config.use_ema:
+            msg = "Multi-Stage training cannot continue if EMA enabled, disable Use EMA." # <= 10GB GPU cannot train with EMA enable
 
     if msg:
         shared.state.textinfo = msg

--- a/dreambooth/train_dreambooth.py
+++ b/dreambooth/train_dreambooth.py
@@ -504,6 +504,9 @@ def main(args: DreamboothConfig, memory_record, use_subdir, lora_model=None, lor
     del text_getter
     cleanup()
 
+    if args.train_in_stages and any(int(getattr(concept, 'num_class_images')) != 0 for concept in args.concepts_list):
+        return args, mem_record, "Stage 0: Complete!"
+
     # Load the tokenizer
     if args.tokenizer_name:
         tokenizer = AutoTokenizer.from_pretrained(


### PR DESCRIPTION
The error:
```
Class dir E:\dreambooth\_REGULARIZATION-IMAGES\1girl has 0 images.
100%|████████████████████████████████████████████████████████████████████████████| 2000/2000 [2:00:02<00:00,  3.60s/it]

Traceback (most recent call last):
  File "E:\stable-diffusion-webui\extensions\sd_dreambooth_extension\dreambooth\train_dreambooth.py", line 1043, in main
    noise_pred, noise_pred_prior = torch.chunk(noise_pred, 2, dim=0)
ValueError: not enough values to unpack (expected 2, got 1)
```

due to the sequence does not contain enough elements when in Multi-Stage Training...

Simple fix doing this `x, y, *_ = [1]`, might have unattended side effect, best is restart the `main()` training when done Generate Class Image

Also move `foreach` loop inside closer to `main()` training function

as Multi-Stage Training for 10GB GPU now have 3 Levels:
Stage 0 = Generate Image Class (If available)
Stage 1 = Text Encoder
Stage 2 = UNET

Hope this works ♥